### PR TITLE
feat: add settings and plugin management actions

### DIFF
--- a/actions/activate-plugin.php
+++ b/actions/activate-plugin.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Activate Plugin Action.
+ *
+ * Activates an installed WordPress plugin by its plugin file path.
+ * Validates the plugin exists in the installed plugins list before activating.
+ *
+ * @package WPAgent\Actions
+ * @since   1.0.0
+ */
+
+namespace WPAgent\Actions;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Activate_Plugin
+ *
+ * @since 1.0.0
+ */
+class Activate_Plugin implements Action_Interface {
+
+	/**
+	 * Get the action name.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'activate_plugin';
+	}
+
+	/**
+	 * Get the action description.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_description(): string {
+		return 'Activate an installed WordPress plugin. Requires the plugin file path '
+			. '(e.g. "akismet/akismet.php", "hello.php"). The plugin must already be installed.';
+	}
+
+	/**
+	 * Get the JSON Schema for parameters.
+	 *
+	 * @since 1.0.0
+	 * @return array
+	 */
+	public function get_parameters(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'plugin' => [
+					'type'        => 'string',
+					'description' => 'The plugin file path relative to the plugins directory (e.g. "akismet/akismet.php").',
+				],
+			],
+			'required'   => [ 'plugin' ],
+		];
+	}
+
+	/**
+	 * Get the required capability.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_capabilities_required(): string {
+		return 'activate_plugins';
+	}
+
+	/**
+	 * Whether this action is reversible.
+	 *
+	 * @since 1.0.0
+	 * @return bool
+	 */
+	public function is_reversible(): bool {
+		return true;
+	}
+
+	/**
+	 * Execute the action.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $params Validated parameters.
+	 * @return array Execution result.
+	 */
+	public function execute( array $params ): array {
+		$plugin = sanitize_text_field( $params['plugin'] );
+
+		// Validate the file path is safe.
+		if ( 0 !== validate_file( $plugin ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => __( 'Invalid plugin file path.', 'wp-agent' ),
+			];
+		}
+
+		// Load plugin functions if not already available.
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		// Validate the plugin exists in the installed plugins list.
+		$installed_plugins = get_plugins();
+
+		if ( ! isset( $installed_plugins[ $plugin ] ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => sprintf(
+					/* translators: %s: plugin file path */
+					__( 'Plugin "%s" is not installed.', 'wp-agent' ),
+					$plugin
+				),
+			];
+		}
+
+		// Check if already active.
+		if ( is_plugin_active( $plugin ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => sprintf(
+					/* translators: %s: plugin name */
+					__( 'Plugin "%s" is already active.', 'wp-agent' ),
+					$installed_plugins[ $plugin ]['Name']
+				),
+			];
+		}
+
+		// Activate the plugin. Returns null on success or WP_Error on failure.
+		$result = activate_plugin( $plugin );
+
+		if ( is_wp_error( $result ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => sprintf(
+					/* translators: 1: plugin name, 2: error message */
+					__( 'Failed to activate "%1$s": %2$s', 'wp-agent' ),
+					$installed_plugins[ $plugin ]['Name'],
+					$result->get_error_message()
+				),
+			];
+		}
+
+		return [
+			'success' => true,
+			'data'    => [
+				'plugin' => $plugin,
+				'name'   => $installed_plugins[ $plugin ]['Name'],
+			],
+			'message' => sprintf(
+				/* translators: %s: plugin name */
+				__( 'Activated plugin "%s" successfully.', 'wp-agent' ),
+				$installed_plugins[ $plugin ]['Name']
+			),
+		];
+	}
+}

--- a/actions/install-plugin.php
+++ b/actions/install-plugin.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Install Plugin Action.
+ *
+ * Installs a plugin from the WordPress.org repository by slug.
+ * Uses Plugin_Upgrader with a silent skin to suppress output.
+ *
+ * @package WPAgent\Actions
+ * @since   1.0.0
+ */
+
+namespace WPAgent\Actions;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Install_Plugin
+ *
+ * @since 1.0.0
+ */
+class Install_Plugin implements Action_Interface {
+
+	/**
+	 * Get the action name.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'install_plugin';
+	}
+
+	/**
+	 * Get the action description.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_description(): string {
+		return 'Install a plugin from the WordPress.org repository by its slug (e.g. "contact-form-7"). '
+			. 'Does not activate the plugin — use activate_plugin for that.';
+	}
+
+	/**
+	 * Get the JSON Schema for parameters.
+	 *
+	 * @since 1.0.0
+	 * @return array
+	 */
+	public function get_parameters(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'slug' => [
+					'type'        => 'string',
+					'description' => 'The WordPress.org plugin slug (e.g. "contact-form-7", "akismet").',
+				],
+			],
+			'required'   => [ 'slug' ],
+		];
+	}
+
+	/**
+	 * Get the required capability.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_capabilities_required(): string {
+		return 'install_plugins';
+	}
+
+	/**
+	 * Whether this action is reversible.
+	 *
+	 * @since 1.0.0
+	 * @return bool
+	 */
+	public function is_reversible(): bool {
+		return true;
+	}
+
+	/**
+	 * Execute the action.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $params Validated parameters.
+	 * @return array Execution result.
+	 */
+	public function execute( array $params ): array {
+		$slug = sanitize_text_field( $params['slug'] );
+
+		// Only allow alphanumeric characters and hyphens in slugs.
+		if ( ! preg_match( '/^[a-z0-9\-]+$/', $slug ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => __( 'Invalid plugin slug. Only lowercase letters, numbers, and hyphens are allowed.', 'wp-agent' ),
+			];
+		}
+
+		// Load required upgrader files.
+		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		// Check if plugin is already installed.
+		$installed_plugins = get_plugins();
+		foreach ( $installed_plugins as $plugin_file => $plugin_data ) {
+			if ( 0 === strpos( $plugin_file, $slug . '/' ) ) {
+				return [
+					'success' => false,
+					'data'    => [
+						'slug'        => $slug,
+						'plugin_file' => $plugin_file,
+					],
+					'message' => sprintf(
+						/* translators: %s: plugin name */
+						__( 'Plugin "%s" is already installed.', 'wp-agent' ),
+						$plugin_data['Name']
+					),
+				];
+			}
+		}
+
+		// Fetch plugin information from WordPress.org API.
+		$api = plugins_api(
+			'plugin_information',
+			[
+				'slug'   => $slug,
+				'fields' => [
+					'sections' => false,
+					'versions' => false,
+				],
+			]
+		);
+
+		if ( is_wp_error( $api ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => sprintf(
+					/* translators: 1: plugin slug, 2: error message */
+					__( 'Could not fetch plugin "%1$s" from WordPress.org: %2$s', 'wp-agent' ),
+					$slug,
+					$api->get_error_message()
+				),
+			];
+		}
+
+		// Install the plugin using silent skin.
+		$skin     = new \WP_Ajax_Upgrader_Skin();
+		$upgrader = new \Plugin_Upgrader( $skin );
+		$result   = $upgrader->install( $api->download_link );
+
+		if ( is_wp_error( $result ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => $result->get_error_message(),
+			];
+		}
+
+		if ( is_wp_error( $skin->result ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => $skin->result->get_error_message(),
+			];
+		}
+
+		if ( ! $result ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => sprintf(
+					/* translators: %s: plugin slug */
+					__( 'Failed to install plugin "%s". Check filesystem permissions.', 'wp-agent' ),
+					$slug
+				),
+			];
+		}
+
+		// Find the installed plugin file.
+		$plugin_file = $upgrader->plugin_info();
+
+		// Re-read plugins to get the installed plugin data.
+		$all_plugins = get_plugins();
+		$plugin_data = isset( $all_plugins[ $plugin_file ] ) ? $all_plugins[ $plugin_file ] : [];
+
+		return [
+			'success' => true,
+			'data'    => [
+				'slug'        => $slug,
+				'name'        => isset( $plugin_data['Name'] ) ? $plugin_data['Name'] : $slug,
+				'version'     => isset( $plugin_data['Version'] ) ? $plugin_data['Version'] : '',
+				'plugin_file' => $plugin_file,
+			],
+			'message' => sprintf(
+				/* translators: 1: plugin name, 2: plugin version */
+				__( 'Installed "%1$s" (v%2$s) successfully. Use activate_plugin to activate it.', 'wp-agent' ),
+				isset( $plugin_data['Name'] ) ? $plugin_data['Name'] : $slug,
+				isset( $plugin_data['Version'] ) ? $plugin_data['Version'] : 'unknown'
+			),
+		];
+	}
+}

--- a/actions/manage-permalinks.php
+++ b/actions/manage-permalinks.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Manage Permalinks Action.
+ *
+ * Updates the WordPress permalink structure and flushes rewrite rules.
+ * Validates that the structure contains at least one rewrite tag.
+ *
+ * @package WPAgent\Actions
+ * @since   1.0.0
+ */
+
+namespace WPAgent\Actions;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Manage_Permalinks
+ *
+ * @since 1.0.0
+ */
+class Manage_Permalinks implements Action_Interface {
+
+	/**
+	 * Get the action name.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'manage_permalinks';
+	}
+
+	/**
+	 * Get the action description.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_description(): string {
+		return 'Update the WordPress permalink structure and flush rewrite rules. '
+			. 'Common presets: Plain = "" (empty), Day and name = "/%year%/%monthnum%/%day%/%postname%/", '
+			. 'Month and name = "/%year%/%monthnum%/%postname%/", Post name = "/%postname%/", '
+			. 'Numeric = "/archives/%post_id%". The structure must contain at least one rewrite tag.';
+	}
+
+	/**
+	 * Get the JSON Schema for parameters.
+	 *
+	 * @since 1.0.0
+	 * @return array
+	 */
+	public function get_parameters(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'structure' => [
+					'type'        => 'string',
+					'description' => 'The permalink structure string (e.g. "/%postname%/", "/%year%/%monthnum%/%postname%/"). Use empty string for plain permalinks.',
+				],
+			],
+			'required'   => [ 'structure' ],
+		];
+	}
+
+	/**
+	 * Get the required capability.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_capabilities_required(): string {
+		return 'manage_options';
+	}
+
+	/**
+	 * Whether this action is reversible.
+	 *
+	 * @since 1.0.0
+	 * @return bool
+	 */
+	public function is_reversible(): bool {
+		return true;
+	}
+
+	/**
+	 * Execute the action.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $params Validated parameters.
+	 * @return array Execution result.
+	 */
+	public function execute( array $params ): array {
+		$structure = sanitize_text_field( $params['structure'] );
+
+		// Allow empty string for "plain" permalinks, but validate non-empty strings.
+		if ( '' !== $structure ) {
+			$valid_tags = [
+				'%year%',
+				'%monthnum%',
+				'%day%',
+				'%hour%',
+				'%minute%',
+				'%second%',
+				'%post_id%',
+				'%postname%',
+				'%category%',
+				'%author%',
+			];
+
+			$has_tag = false;
+			foreach ( $valid_tags as $tag ) {
+				if ( false !== strpos( $structure, $tag ) ) {
+					$has_tag = true;
+					break;
+				}
+			}
+
+			if ( ! $has_tag ) {
+				return [
+					'success' => false,
+					'data'    => null,
+					'message' => __( 'Permalink structure must contain at least one rewrite tag (e.g. %postname%, %post_id%).', 'wp-agent' ),
+				];
+			}
+		}
+
+		$old_structure = get_option( 'permalink_structure' );
+
+		update_option( 'permalink_structure', $structure );
+		flush_rewrite_rules();
+
+		return [
+			'success' => true,
+			'data'    => [
+				'old_structure' => $old_structure,
+				'new_structure' => $structure,
+			],
+			'message' => sprintf(
+				/* translators: 1: old permalink structure, 2: new permalink structure */
+				__( 'Permalink structure updated from "%1$s" to "%2$s". Rewrite rules flushed.', 'wp-agent' ),
+				$old_structure,
+				$structure
+			),
+		];
+	}
+}

--- a/actions/update-settings.php
+++ b/actions/update-settings.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Update Settings Action.
+ *
+ * Updates a WordPress site option from a strict whitelist of safe options.
+ * Stores the old value before updating for checkpoint undo support.
+ *
+ * @package WPAgent\Actions
+ * @since   1.0.0
+ */
+
+namespace WPAgent\Actions;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Update_Settings
+ *
+ * @since 1.0.0
+ */
+class Update_Settings implements Action_Interface {
+
+	/**
+	 * Whitelist of options the AI is allowed to modify.
+	 *
+	 * @var string[]
+	 */
+	const ALLOWED_OPTIONS = [
+		'blogname',
+		'blogdescription',
+		'admin_email',
+		'date_format',
+		'time_format',
+		'timezone_string',
+		'gmt_offset',
+		'start_of_week',
+		'WPLANG',
+		'posts_per_page',
+		'posts_per_rss',
+		'blog_public',
+		'default_category',
+		'default_post_format',
+		'show_on_front',
+		'page_on_front',
+		'page_for_posts',
+		'default_comment_status',
+		'default_ping_status',
+		'comment_moderation',
+		'comment_registration',
+		'close_comments_for_old_posts',
+		'thread_comments',
+		'thread_comments_depth',
+		'comments_per_page',
+	];
+
+	/**
+	 * Get the action name.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'update_settings';
+	}
+
+	/**
+	 * Get the action description.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_description(): string {
+		return 'Update a WordPress site setting. Only whitelisted options are allowed: '
+			. implode( ', ', self::ALLOWED_OPTIONS )
+			. '. Rejects any option not in this list.';
+	}
+
+	/**
+	 * Get the JSON Schema for parameters.
+	 *
+	 * @since 1.0.0
+	 * @return array
+	 */
+	public function get_parameters(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'option_name'  => [
+					'type'        => 'string',
+					'description' => 'The option name to update. Must be one of the whitelisted options.',
+					'enum'        => self::ALLOWED_OPTIONS,
+				],
+				'option_value' => [
+					'type'        => [ 'string', 'integer', 'boolean' ],
+					'description' => 'The new value for the option.',
+				],
+			],
+			'required'   => [ 'option_name', 'option_value' ],
+		];
+	}
+
+	/**
+	 * Get the required capability.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_capabilities_required(): string {
+		return 'manage_options';
+	}
+
+	/**
+	 * Whether this action is reversible.
+	 *
+	 * @since 1.0.0
+	 * @return bool
+	 */
+	public function is_reversible(): bool {
+		return true;
+	}
+
+	/**
+	 * Execute the action.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $params Validated parameters.
+	 * @return array Execution result.
+	 */
+	public function execute( array $params ): array {
+		$option_name = sanitize_text_field( $params['option_name'] );
+
+		if ( ! in_array( $option_name, self::ALLOWED_OPTIONS, true ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => sprintf(
+					/* translators: %s: option name */
+					__( 'Option "%s" is not in the allowed whitelist.', 'wp-agent' ),
+					$option_name
+				),
+			];
+		}
+
+		$old_value = get_option( $option_name );
+		$new_value = $params['option_value'];
+
+		// Sanitize based on expected types.
+		if ( is_numeric( $new_value ) && in_array( $option_name, [ 'posts_per_page', 'posts_per_rss', 'start_of_week', 'gmt_offset', 'page_on_front', 'page_for_posts', 'default_category', 'thread_comments_depth', 'comments_per_page', 'blog_public' ], true ) ) {
+			$new_value = intval( $new_value );
+		} else {
+			$new_value = sanitize_text_field( (string) $new_value );
+		}
+
+		$updated = update_option( $option_name, $new_value );
+
+		if ( ! $updated && get_option( $option_name ) !== $new_value ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => sprintf(
+					/* translators: %s: option name */
+					__( 'Failed to update option "%s".', 'wp-agent' ),
+					$option_name
+				),
+			];
+		}
+
+		return [
+			'success' => true,
+			'data'    => [
+				'option_name' => $option_name,
+				'old_value'   => $old_value,
+				'new_value'   => $new_value,
+			],
+			'message' => sprintf(
+				/* translators: %s: option name */
+				__( 'Updated option "%s" successfully.', 'wp-agent' ),
+				$option_name
+			),
+		];
+	}
+}

--- a/plugin-loader.php
+++ b/plugin-loader.php
@@ -83,7 +83,7 @@ class Plugin_Loader {
 	}
 
 	/**
-	 * Register core content actions.
+	 * Register core actions.
 	 *
 	 * @since 1.0.0
 	 *
@@ -91,11 +91,18 @@ class Plugin_Loader {
 	 * @return void
 	 */
 	public function register_core_actions( $registry ) {
+		// Content actions.
 		$registry->register( new Actions\Create_Post() );
 		$registry->register( new Actions\Edit_Post() );
 		$registry->register( new Actions\Delete_Post() );
 		$registry->register( new Actions\Read_Blocks() );
 		$registry->register( new Actions\Insert_Blocks() );
+
+		// Settings & plugin management actions.
+		$registry->register( new Actions\Update_Settings() );
+		$registry->register( new Actions\Manage_Permalinks() );
+		$registry->register( new Actions\Install_Plugin() );
+		$registry->register( new Actions\Activate_Plugin() );
 	}
 
 	/**


### PR DESCRIPTION
## **User description**
## Summary
- Add 4 new server-side actions: `update_settings`, `manage_permalinks`, `install_plugin`, `activate_plugin`
- Update `plugin-loader.php` to register all 9 actions (5 content + 4 settings/plugin)
- Strict security: option whitelist, slug regex validation, path traversal protection

Closes #13

## Test plan
- [x] PHP lint passes on all 5 changed files
- [x] Autoloader mapping verified for all 4 new classes
- [x] 23/23 smoke tests passed (registry count, whitelist rejection, tag validation, slug sanitization, already-installed/active detection)
- [x] Plugin activates clean with no PHP errors


___

## **CodeAnt-AI Description**
**Add managed settings and plugin install/activate actions**

### What Changed
- Adds four new user-facing actions: update site settings from a strict whitelist, change permalink structure with validation and rewrite flush, install a plugin from WordPress.org by slug, and activate an installed plugin by its plugin file path.
- Settings updates only accept a fixed list of safe options and return the previous value so changes can be inspected or undone; numeric and text inputs are sanitized.
- Permalink updates reject structures that contain no rewrite tags and flush rewrite rules after applying the new structure.
- Plugin install checks WordPress.org for the slug, prevents re-installing an already-installed plugin, reports install errors (including filesystem/permission issues), and returns installed plugin metadata; activation validates the plugin is installed and reports if it's already active or if activation fails.

### Impact
`✅ Safer settings updates`
`✅ Clearer plugin install/activation errors`
`✅ Immediate permalink changes with rewrite flush`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
