### PR TITLE
feat: add user and system actions (deactivate-plugin, create-user, site-health)

### DIFF
--- a/actions/create-user.php
+++ b/actions/create-user.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Create User Action.
+ *
+ * Creates a new WordPress user with an auto-generated password.
+ * Validates username and email uniqueness, and restricts role assignment
+ * based on the current user's capabilities.
+ *
+ * @package WPAgent\Actions
+ * @since   1.0.0
+ */
+
+namespace WPAgent\Actions;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Create_User
+ *
+ * @since 1.0.0
+ */
+class Create_User implements Action_Interface {
+
+	/**
+	 * Get the action name.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'create_user';
+	}
+
+	/**
+	 * Get the action description.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_description(): string {
+		return 'Create a new WordPress user. A strong password is auto-generated '
+			. '(never accepts user-supplied passwords). Defaults to the "subscriber" role.';
+	}
+
+	/**
+	 * Get the JSON Schema for parameters.
+	 *
+	 * @since 1.0.0
+	 * @return array
+	 */
+	public function get_parameters(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'user_login'   => [
+					'type'        => 'string',
+					'description' => 'The username for the new user.',
+				],
+				'user_email'   => [
+					'type'        => 'string',
+					'description' => 'The email address for the new user.',
+				],
+				'role'         => [
+					'type'        => 'string',
+					'description' => 'The role to assign (e.g. "subscriber", "editor", "author"). Defaults to "subscriber".',
+				],
+				'first_name'   => [
+					'type'        => 'string',
+					'description' => 'The user\'s first name.',
+				],
+				'last_name'    => [
+					'type'        => 'string',
+					'description' => 'The user\'s last name.',
+				],
+				'display_name' => [
+					'type'        => 'string',
+					'description' => 'The display name for the user.',
+				],
+			],
+			'required'   => [ 'user_login', 'user_email' ],
+		];
+	}
+
+	/**
+	 * Get the required capability.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_capabilities_required(): string {
+		return 'create_users';
+	}
+
+	/**
+	 * Whether this action is reversible.
+	 *
+	 * @since 1.0.0
+	 * @return bool
+	 */
+	public function is_reversible(): bool {
+		return true;
+	}
+
+	/**
+	 * Execute the action.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $params Validated parameters.
+	 * @return array Execution result.
+	 */
+	public function execute( array $params ): array {
+		$user_login = sanitize_user( $params['user_login'], true );
+		$user_email = sanitize_email( $params['user_email'] );
+		$role       = isset( $params['role'] ) ? sanitize_text_field( $params['role'] ) : 'subscriber';
+
+		// Validate username is not empty after sanitization.
+		if ( empty( $user_login ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => __( 'Invalid username. Username must contain valid characters.', 'wp-agent' ),
+			];
+		}
+
+		// Validate email format.
+		if ( ! is_email( $user_email ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => __( 'Invalid email address.', 'wp-agent' ),
+			];
+		}
+
+		// Check username uniqueness.
+		if ( username_exists( $user_login ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => sprintf(
+					/* translators: %s: username */
+					__( 'Username "%s" already exists.', 'wp-agent' ),
+					$user_login
+				),
+			];
+		}
+
+		// Check email uniqueness.
+		if ( email_exists( $user_email ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => sprintf(
+					/* translators: %s: email address */
+					__( 'Email "%s" is already registered.', 'wp-agent' ),
+					$user_email
+				),
+			];
+		}
+
+		// Validate role exists.
+		$valid_roles = wp_roles()->get_names();
+		if ( ! isset( $valid_roles[ $role ] ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => sprintf(
+					/* translators: %s: role name */
+					__( 'Invalid role "%s".', 'wp-agent' ),
+					$role
+				),
+			];
+		}
+
+		// Restrict role assignment: non-admins cannot assign administrator role.
+		if ( 'administrator' === $role && ! current_user_can( 'manage_options' ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => __( 'You do not have permission to assign the administrator role.', 'wp-agent' ),
+			];
+		}
+
+		// Build the user data array.
+		$userdata = [
+			'user_login' => $user_login,
+			'user_email' => $user_email,
+			'user_pass'  => wp_generate_password( 24, true, true ),
+			'role'       => $role,
+		];
+
+		if ( ! empty( $params['first_name'] ) ) {
+			$userdata['first_name'] = sanitize_text_field( $params['first_name'] );
+		}
+
+		if ( ! empty( $params['last_name'] ) ) {
+			$userdata['last_name'] = sanitize_text_field( $params['last_name'] );
+		}
+
+		if ( ! empty( $params['display_name'] ) ) {
+			$userdata['display_name'] = sanitize_text_field( $params['display_name'] );
+		}
+
+		// Create the user.
+		$user_id = wp_insert_user( $userdata );
+
+		if ( is_wp_error( $user_id ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => sprintf(
+					/* translators: %s: error message */
+					__( 'Failed to create user: %s', 'wp-agent' ),
+					$user_id->get_error_message()
+				),
+			];
+		}
+
+		return [
+			'success' => true,
+			'data'    => [
+				'user_id'    => $user_id,
+				'user_login' => $user_login,
+				'role'       => $role,
+				'edit_url'   => admin_url( 'user-edit.php?user_id=' . $user_id ),
+			],
+			'message' => sprintf(
+				/* translators: 1: username, 2: role */
+				__( 'Created user "%1$s" with the "%2$s" role. A password was auto-generated.', 'wp-agent' ),
+				$user_login,
+				$valid_roles[ $role ]
+			),
+		];
+	}
+}

--- a/actions/deactivate-plugin.php
+++ b/actions/deactivate-plugin.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Deactivate Plugin Action.
+ *
+ * Deactivates an active WordPress plugin by its plugin file path.
+ * Validates the plugin exists and is currently active before deactivating.
+ * Includes a self-deactivation guard to prevent WP Agent from deactivating itself.
+ *
+ * @package WPAgent\Actions
+ * @since   1.0.0
+ */
+
+namespace WPAgent\Actions;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Deactivate_Plugin
+ *
+ * @since 1.0.0
+ */
+class Deactivate_Plugin implements Action_Interface {
+
+	/**
+	 * Get the action name.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'deactivate_plugin';
+	}
+
+	/**
+	 * Get the action description.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_description(): string {
+		return 'Deactivate a currently active WordPress plugin. Requires the plugin file path '
+			. '(e.g. "akismet/akismet.php", "hello.php"). Cannot deactivate WP Agent itself.';
+	}
+
+	/**
+	 * Get the JSON Schema for parameters.
+	 *
+	 * @since 1.0.0
+	 * @return array
+	 */
+	public function get_parameters(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'plugin' => [
+					'type'        => 'string',
+					'description' => 'The plugin file path relative to the plugins directory (e.g. "akismet/akismet.php").',
+				],
+			],
+			'required'   => [ 'plugin' ],
+		];
+	}
+
+	/**
+	 * Get the required capability.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_capabilities_required(): string {
+		return 'activate_plugins';
+	}
+
+	/**
+	 * Whether this action is reversible.
+	 *
+	 * @since 1.0.0
+	 * @return bool
+	 */
+	public function is_reversible(): bool {
+		return true;
+	}
+
+	/**
+	 * Execute the action.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $params Validated parameters.
+	 * @return array Execution result.
+	 */
+	public function execute( array $params ): array {
+		$plugin = sanitize_text_field( $params['plugin'] );
+
+		// Validate the file path is safe.
+		if ( 0 !== validate_file( $plugin ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => __( 'Invalid plugin file path.', 'wp-agent' ),
+			];
+		}
+
+		// Self-deactivation guard: prevent deactivating WP Agent itself.
+		if ( defined( 'WP_AGENT_BASE' ) && WP_AGENT_BASE === $plugin ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => __( 'Cannot deactivate WP Agent through its own action system.', 'wp-agent' ),
+			];
+		}
+
+		// Load plugin functions if not already available.
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		// Validate the plugin exists in the installed plugins list.
+		$installed_plugins = get_plugins();
+
+		if ( ! isset( $installed_plugins[ $plugin ] ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => sprintf(
+					/* translators: %s: plugin file path */
+					__( 'Plugin "%s" is not installed.', 'wp-agent' ),
+					$plugin
+				),
+			];
+		}
+
+		// Check if already inactive.
+		if ( ! is_plugin_active( $plugin ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => sprintf(
+					/* translators: %s: plugin name */
+					__( 'Plugin "%s" is already inactive.', 'wp-agent' ),
+					$installed_plugins[ $plugin ]['Name']
+				),
+			];
+		}
+
+		// Deactivate the plugin.
+		deactivate_plugins( [ $plugin ] );
+
+		// Verify deactivation succeeded.
+		if ( is_plugin_active( $plugin ) ) {
+			return [
+				'success' => false,
+				'data'    => null,
+				'message' => sprintf(
+					/* translators: %s: plugin name */
+					__( 'Failed to deactivate "%s".', 'wp-agent' ),
+					$installed_plugins[ $plugin ]['Name']
+				),
+			];
+		}
+
+		return [
+			'success' => true,
+			'data'    => [
+				'plugin' => $plugin,
+				'name'   => $installed_plugins[ $plugin ]['Name'],
+			],
+			'message' => sprintf(
+				/* translators: %s: plugin name */
+				__( 'Deactivated plugin "%s" successfully.', 'wp-agent' ),
+				$installed_plugins[ $plugin ]['Name']
+			),
+		];
+	}
+}

--- a/actions/site-health.php
+++ b/actions/site-health.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Site Health Action.
+ *
+ * Runs WordPress Site Health direct tests and returns diagnostic results.
+ * Read-only — does not modify the site. Skips async tests (loopback, dotorg)
+ * to avoid slow external requests.
+ *
+ * @package WPAgent\Actions
+ * @since   1.0.0
+ */
+
+namespace WPAgent\Actions;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Site_Health
+ *
+ * @since 1.0.0
+ */
+class Site_Health implements Action_Interface {
+
+	/**
+	 * Get the action name.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'site_health';
+	}
+
+	/**
+	 * Get the action description.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_description(): string {
+		return 'Run WordPress Site Health diagnostics and return the results. '
+			. 'Read-only — does not modify the site. Can filter by category: "security", "performance", or "all".';
+	}
+
+	/**
+	 * Get the JSON Schema for parameters.
+	 *
+	 * @since 1.0.0
+	 * @return array
+	 */
+	public function get_parameters(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'category' => [
+					'type'        => 'string',
+					'description' => 'Filter results by category: "security", "performance", or "all". Defaults to "all".',
+					'enum'        => [ 'all', 'security', 'performance' ],
+				],
+			],
+			'required'   => [],
+		];
+	}
+
+	/**
+	 * Get the required capability.
+	 *
+	 * @since 1.0.0
+	 * @return string
+	 */
+	public function get_capabilities_required(): string {
+		return 'view_site_health_checks';
+	}
+
+	/**
+	 * Whether this action is reversible.
+	 *
+	 * @since 1.0.0
+	 * @return bool
+	 */
+	public function is_reversible(): bool {
+		return false;
+	}
+
+	/**
+	 * Execute the action.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $params Validated parameters.
+	 * @return array Execution result.
+	 */
+	public function execute( array $params ): array {
+		$category = isset( $params['category'] ) ? sanitize_text_field( $params['category'] ) : 'all';
+
+		// Load admin includes that Site Health tests depend on.
+		if ( ! function_exists( 'get_core_updates' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/update.php';
+		}
+		if ( ! function_exists( 'got_url_rewrite' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/misc.php';
+		}
+		if ( ! class_exists( 'WP_Site_Health' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-site-health.php';
+		}
+
+		$site_health = \WP_Site_Health::get_instance();
+		$all_tests   = \WP_Site_Health::get_tests();
+
+		// Only run direct tests (skip async tests which make external requests).
+		if ( empty( $all_tests['direct'] ) || ! is_array( $all_tests['direct'] ) ) {
+			return [
+				'success' => true,
+				'data'    => [
+					'total'       => 0,
+					'good'        => 0,
+					'recommended' => 0,
+					'critical'    => 0,
+					'results'     => [],
+				],
+				'message' => __( 'No direct Site Health tests available.', 'wp-agent' ),
+			];
+		}
+
+		$results     = [];
+		$good        = 0;
+		$recommended = 0;
+		$critical    = 0;
+
+		foreach ( $all_tests['direct'] as $test_key => $test_info ) {
+			// Each direct test has a callback that returns a result array.
+			$test_function = false;
+			if ( isset( $test_info['test'] ) && is_string( $test_info['test'] ) ) {
+				$method = 'get_test_' . $test_info['test'];
+				if ( method_exists( $site_health, $method ) ) {
+					$test_function = [ $site_health, $method ];
+				}
+			} elseif ( isset( $test_info['test'] ) && is_callable( $test_info['test'] ) ) {
+				$test_function = $test_info['test'];
+			}
+
+			if ( ! $test_function || ! is_callable( $test_function ) ) {
+				continue;
+			}
+
+			// Run the test safely — skip if it throws.
+			try {
+				$result = call_user_func( $test_function );
+			} catch ( \Throwable $e ) {
+				continue;
+			}
+
+			if ( ! is_array( $result ) || empty( $result['status'] ) ) {
+				continue;
+			}
+
+			// Apply category filter based on badge label.
+			if ( 'all' !== $category ) {
+				$badge_label = isset( $result['badge']['label'] ) ? strtolower( $result['badge']['label'] ) : '';
+				if ( $badge_label !== $category ) {
+					continue;
+				}
+			}
+
+			// Strip HTML from description and label.
+			$label       = isset( $result['label'] ) ? wp_strip_all_tags( $result['label'] ) : $test_key;
+			$badge_label = isset( $result['badge']['label'] ) ? wp_strip_all_tags( $result['badge']['label'] ) : '';
+
+			$results[] = [
+				'test'        => $test_key,
+				'label'       => $label,
+				'status'      => $result['status'],
+				'badge_label' => $badge_label,
+			];
+
+			// Count by status.
+			switch ( $result['status'] ) {
+				case 'good':
+					++$good;
+					break;
+				case 'recommended':
+					++$recommended;
+					break;
+				case 'critical':
+					++$critical;
+					break;
+			}
+		}
+
+		$total = count( $results );
+
+		return [
+			'success' => true,
+			'data'    => [
+				'total'       => $total,
+				'good'        => $good,
+				'recommended' => $recommended,
+				'critical'    => $critical,
+				'results'     => $results,
+			],
+			'message' => sprintf(
+				/* translators: 1: total tests, 2: good count, 3: recommended count, 4: critical count */
+				__( 'Site Health: %1$d tests — %2$d good, %3$d recommended, %4$d critical.', 'wp-agent' ),
+				$total,
+				$good,
+				$recommended,
+				$critical
+			),
+		];
+	}
+}

--- a/plugin-loader.php
+++ b/plugin-loader.php
@@ -103,6 +103,11 @@ class Plugin_Loader {
 		$registry->register( new Actions\Manage_Permalinks() );
 		$registry->register( new Actions\Install_Plugin() );
 		$registry->register( new Actions\Activate_Plugin() );
+
+		// User & system actions.
+		$registry->register( new Actions\Deactivate_Plugin() );
+		$registry->register( new Actions\Create_User() );
+		$registry->register( new Actions\Site_Health() );
 	}
 
 	/**


### PR DESCRIPTION
## **User description**
## Summary
- Add `deactivate_plugin` action with self-deactivation guard
- Add `create_user` action with auto-generated passwords and role restriction
- Add `site_health` action for read-only WordPress diagnostics
- Register all 3 in plugin-loader.php — completes all 12 Phase 1 actions

Closes #15

## Test plan
- [ ] Plugin activates clean (no PHP errors)
- [ ] `get_tool_definitions()` returns 12 items for admin user
- [ ] `deactivate_plugin` rejects self-deactivation (`wp-plugin-base/wp-agent.php`)
- [ ] `deactivate_plugin` rejects non-installed plugin
- [ ] `create_user` creates subscriber with auto-generated password
- [ ] `create_user` rejects duplicate username and duplicate email
- [ ] `site_health` returns structured results with good/recommended/critical counts
- [ ] Smoke test: 25/25 passed


___

## **CodeAnt-AI Description**
Add plugin deactivation, user creation, and site health diagnostics actions

### What Changed
- Registers three new admin actions: deactivate_plugin, create_user, and site_health.
- deactivate_plugin: deactivates an installed active plugin by file path, rejects invalid or already-inactive plugins, and prevents the agent from deactivating itself.
- create_user: creates a new user with an auto-generated strong password, enforces unique username/email, validates role, and blocks non-admins from assigning the administrator role.
- site_health: runs WordPress Site Health direct (non-async) tests, supports filtering by "security", "performance", or "all", and returns structured counts and test results.

### Impact
`✅ Clearer plugin deactivation errors`
`✅ Safer user creation with auto-generated passwords`
`✅ Faster diagnostics without external requests`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
