### PR TITLE
feat: add REST API endpoints and wire up settings persistence

### DIFF
--- a/admin/assets-manager.php
+++ b/admin/assets-manager.php
@@ -101,7 +101,7 @@ class Assets_Manager {
 			[
 				'restUrl'   => rest_url( 'wp-agent/v1/' ),
 				'nonce'     => wp_create_nonce( 'wp_rest' ),
-				'hasApiKey' => ! empty( get_option( 'wp_agent_api_key' ) ),
+				'hasApiKey' => ! empty( get_option( \WPAgent\AI\Open_Router_Client::API_KEY_OPTION ) ),
 				'userId'    => get_current_user_id(),
 				'userName'  => wp_get_current_user()->display_name,
 				'version'   => WP_AGENT_VER,

--- a/plugin-loader.php
+++ b/plugin-loader.php
@@ -79,7 +79,22 @@ class Plugin_Loader {
 		add_action( 'plugins_loaded', [ $this, 'load_textdomain' ] );
 		add_action( 'plugins_loaded', [ $this, 'load_admin' ] );
 		add_action( 'admin_init', [ 'WPAgent\Core\Database', 'maybe_upgrade' ] );
+		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ] );
 		add_action( 'wp_agent_register_actions', [ $this, 'register_core_actions' ] );
+	}
+
+	/**
+	 * Register REST API routes.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	public function register_rest_routes() {
+		( new REST\Settings_Controller() )->register_routes();
+		( new REST\Chat_Controller() )->register_routes();
+		( new REST\Stream_Controller() )->register_routes();
+		( new REST\History_Controller() )->register_routes();
+		( new REST\Action_Controller() )->register_routes();
 	}
 
 	/**

--- a/rest/action-controller.php
+++ b/rest/action-controller.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ * Action REST Controller.
+ *
+ * Direct action dispatch and undo endpoints. Allows the frontend to
+ * execute actions outside of a chat flow and undo checkpointed actions.
+ *
+ * @package WPAgent\REST
+ * @since   1.0.0
+ */
+
+namespace WPAgent\REST;
+
+use WPAgent\Actions\Action_Registry;
+use WPAgent\Core\Database;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Action_Controller
+ *
+ * @since 1.0.0
+ */
+class Action_Controller {
+
+	/**
+	 * REST namespace.
+	 *
+	 * @var string
+	 */
+	const NAMESPACE = 'wp-agent/v1';
+
+	/**
+	 * Register REST routes.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	public function register_routes() {
+		// POST /action/execute — dispatch an action.
+		register_rest_route(
+			self::NAMESPACE,
+			'/action/execute',
+			[
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'execute_action' ],
+				'permission_callback' => [ $this, 'check_execute_permissions' ],
+				'args'                => [
+					'action' => [
+						'required'          => true,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'params' => [
+						'type'              => 'object',
+						'default'           => [],
+						'sanitize_callback' => function ( $params ) {
+							if ( ! is_array( $params ) ) {
+								return [];
+							}
+							return map_deep( $params, 'sanitize_text_field' );
+						},
+					],
+				],
+			]
+		);
+
+		// POST /action/undo — restore a checkpoint.
+		register_rest_route(
+			self::NAMESPACE,
+			'/action/undo',
+			[
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'undo_action' ],
+				'permission_callback' => [ $this, 'check_undo_permissions' ],
+				'args'                => [
+					'checkpoint_id' => [
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Permission check for execute — edit_posts as baseline.
+	 *
+	 * Per-action capability checks happen inside Action_Registry::dispatch().
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return bool|\WP_Error
+	 */
+	public function check_execute_permissions( $request ) {
+		if ( ! current_user_can( 'edit_posts' ) || ! REST_Permissions::current_user_has_allowed_role() ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to execute actions.', 'wp-agent' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Permission check for undo — edit_posts required.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return bool|\WP_Error
+	 */
+	public function check_undo_permissions( $request ) {
+		if ( ! current_user_can( 'edit_posts' ) || ! REST_Permissions::current_user_has_allowed_role() ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to undo actions.', 'wp-agent' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * POST /wp-agent/v1/action/execute
+	 *
+	 * Dispatches an action through the Action Registry.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function execute_action( $request ) {
+		$action_name = $request->get_param( 'action' );
+		$params      = $request->get_param( 'params' );
+
+		if ( ! is_array( $params ) ) {
+			$params = [];
+		}
+
+		$result = Action_Registry::get_instance()->dispatch( $action_name, $params );
+
+		if ( is_wp_error( $result ) ) {
+			$status = $result->get_error_data() && isset( $result->get_error_data()['status'] )
+				? $result->get_error_data()['status']
+				: 400;
+
+			return new \WP_Error(
+				$result->get_error_code(),
+				$result->get_error_message(),
+				[ 'status' => $status ]
+			);
+		}
+
+		return rest_ensure_response( $result );
+	}
+
+	/**
+	 * POST /wp-agent/v1/action/undo
+	 *
+	 * Marks a checkpoint as restored. Full snapshot restore logic
+	 * will be implemented with the sidebar UI.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function undo_action( $request ) {
+		global $wpdb;
+
+		$checkpoint_id = (int) $request->get_param( 'checkpoint_id' );
+		$tables        = Database::get_table_names();
+		$user_id       = get_current_user_id();
+
+		// Verify checkpoint exists and belongs to a conversation owned by the current user.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$checkpoint = $wpdb->get_row(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT cp.id, cp.is_restored, cp.action_type, c.user_id
+				FROM {$tables['checkpoints']} cp
+				INNER JOIN {$tables['conversations']} c ON c.id = cp.conversation_id
+				WHERE cp.id = %d
+				LIMIT 1",
+				$checkpoint_id
+			),
+			ARRAY_A
+		);
+
+		if ( null === $checkpoint ) {
+			return new \WP_Error(
+				'not_found',
+				__( 'Checkpoint not found.', 'wp-agent' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		if ( (int) $checkpoint['user_id'] !== $user_id ) {
+			return new \WP_Error(
+				'forbidden',
+				__( 'You do not have access to this checkpoint.', 'wp-agent' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		if ( (int) $checkpoint['is_restored'] ) {
+			return new \WP_Error(
+				'already_restored',
+				__( 'This checkpoint has already been restored.', 'wp-agent' ),
+				[ 'status' => 409 ]
+			);
+		}
+
+		// Mark as restored.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $wpdb->update(
+			$tables['checkpoints'],
+			[ 'is_restored' => 1 ],
+			[ 'id' => $checkpoint_id ],
+			[ '%d' ],
+			[ '%d' ]
+		);
+
+		if ( false === $updated ) {
+			return new \WP_Error(
+				'db_error',
+				__( 'Failed to mark checkpoint as restored.', 'wp-agent' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		return rest_ensure_response( [
+			'success'       => true,
+			'checkpoint_id' => $checkpoint_id,
+			'action_type'   => $checkpoint['action_type'],
+		] );
+	}
+}

--- a/rest/chat-controller.php
+++ b/rest/chat-controller.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Chat REST Controller.
+ *
+ * Non-streaming chat endpoint. Receives a message, calls the orchestrator,
+ * and returns the full response synchronously.
+ *
+ * @package WPAgent\REST
+ * @since   1.0.0
+ */
+
+namespace WPAgent\REST;
+
+use WPAgent\AI\Orchestrator;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Chat_Controller
+ *
+ * @since 1.0.0
+ */
+class Chat_Controller {
+
+	/**
+	 * REST namespace.
+	 *
+	 * @var string
+	 */
+	const NAMESPACE = 'wp-agent/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	const ROUTE = '/chat';
+
+	/**
+	 * Register REST routes.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			self::NAMESPACE,
+			self::ROUTE,
+			[
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'handle_chat' ],
+				'permission_callback' => [ $this, 'check_permissions' ],
+				'args'                => $this->get_args(),
+			]
+		);
+	}
+
+	/**
+	 * Permission check — edit_posts required.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return bool|\WP_Error
+	 */
+	public function check_permissions( $request ) {
+		if ( ! current_user_can( 'edit_posts' ) || ! REST_Permissions::current_user_has_allowed_role() ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to use the chat.', 'wp-agent' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * POST /wp-agent/v1/chat
+	 *
+	 * Sends a message to the AI orchestrator and returns the response.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function handle_chat( $request ) {
+		$message         = $request->get_param( 'message' );
+		$conversation_id = $request->get_param( 'conversation_id' );
+		$user_id         = get_current_user_id();
+
+		$options = [];
+
+		if ( $request->has_param( 'post_id' ) ) {
+			$options['post_id'] = (int) $request->get_param( 'post_id' );
+		}
+
+		if ( $request->has_param( 'model' ) ) {
+			$options['model'] = sanitize_text_field( $request->get_param( 'model' ) );
+		}
+
+		$result = Orchestrator::get_instance()->handle(
+			$message,
+			$user_id,
+			$conversation_id ? (int) $conversation_id : null,
+			$options
+		);
+
+		if ( is_wp_error( $result ) ) {
+			$status = $result->get_error_data() && isset( $result->get_error_data()['status'] )
+				? $result->get_error_data()['status']
+				: 500;
+
+			return new \WP_Error(
+				$result->get_error_code(),
+				$result->get_error_message(),
+				[ 'status' => $status ]
+			);
+		}
+
+		return rest_ensure_response( $result );
+	}
+
+	/**
+	 * Define argument schema for POST /chat.
+	 *
+	 * @since 1.0.0
+	 * @return array
+	 */
+	private function get_args() {
+		return [
+			'message'         => [
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_textarea_field',
+				'validate_callback' => function ( $value ) {
+					if ( empty( trim( $value ) ) ) {
+						return new \WP_Error(
+							'empty_message',
+							__( 'Message cannot be empty.', 'wp-agent' ),
+							[ 'status' => 400 ]
+						);
+					}
+					return true;
+				},
+			],
+			'conversation_id' => [
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+			],
+			'post_id'         => [
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+			],
+			'model'           => [
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+		];
+	}
+}

--- a/rest/history-controller.php
+++ b/rest/history-controller.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * History REST Controller.
+ *
+ * Provides conversation list and detail endpoints for the current user.
+ * All queries are scoped to the authenticated user — no cross-user access.
+ *
+ * @package WPAgent\REST
+ * @since   1.0.0
+ */
+
+namespace WPAgent\REST;
+
+use WPAgent\Core\Database;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class History_Controller
+ *
+ * @since 1.0.0
+ */
+class History_Controller {
+
+	/**
+	 * REST namespace.
+	 *
+	 * @var string
+	 */
+	const NAMESPACE = 'wp-agent/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	const ROUTE = '/history';
+
+	/**
+	 * Default items per page.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_PER_PAGE = 20;
+
+	/**
+	 * Maximum items per page.
+	 *
+	 * @var int
+	 */
+	const MAX_PER_PAGE = 100;
+
+	/**
+	 * Register REST routes.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	public function register_routes() {
+		// GET /history — paginated conversation list.
+		register_rest_route(
+			self::NAMESPACE,
+			self::ROUTE,
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'list_conversations' ],
+				'permission_callback' => [ $this, 'check_permissions' ],
+				'args'                => $this->get_list_args(),
+			]
+		);
+
+		// GET /history/<id> — single conversation with messages.
+		register_rest_route(
+			self::NAMESPACE,
+			self::ROUTE . '/(?P<id>\d+)',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_conversation' ],
+				'permission_callback' => [ $this, 'check_permissions' ],
+				'args'                => [
+					'id' => [
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Permission check — edit_posts required.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return bool|\WP_Error
+	 */
+	public function check_permissions( $request ) {
+		if ( ! current_user_can( 'edit_posts' ) || ! REST_Permissions::current_user_has_allowed_role() ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to view chat history.', 'wp-agent' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * GET /wp-agent/v1/history
+	 *
+	 * Returns a paginated list of the current user's conversations.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return \WP_REST_Response
+	 */
+	public function list_conversations( $request ) {
+		global $wpdb;
+
+		$tables   = Database::get_table_names();
+		$user_id  = get_current_user_id();
+		$page     = max( 1, (int) $request->get_param( 'page' ) );
+		$per_page = min( self::MAX_PER_PAGE, max( 1, (int) $request->get_param( 'per_page' ) ?: self::DEFAULT_PER_PAGE ) );
+		$offset   = ( $page - 1 ) * $per_page;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$total = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT COUNT(*) FROM {$tables['conversations']} WHERE user_id = %d",
+				$user_id
+			)
+		);
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$conversations = $wpdb->get_results(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT id, post_id, title, status, model, tokens_used, created_at, updated_at
+				FROM {$tables['conversations']}
+				WHERE user_id = %d
+				ORDER BY updated_at DESC
+				LIMIT %d OFFSET %d",
+				$user_id,
+				$per_page,
+				$offset
+			),
+			ARRAY_A
+		);
+
+		if ( null === $conversations ) {
+			$conversations = [];
+		}
+
+		// Cast numeric fields.
+		foreach ( $conversations as &$conv ) {
+			$conv['id']          = (int) $conv['id'];
+			$conv['post_id']     = $conv['post_id'] ? (int) $conv['post_id'] : null;
+			$conv['tokens_used'] = (int) $conv['tokens_used'];
+		}
+		unset( $conv );
+
+		$response = rest_ensure_response( [
+			'conversations' => $conversations,
+			'total'         => $total,
+			'page'          => $page,
+			'per_page'      => $per_page,
+			'total_pages'   => (int) ceil( $total / $per_page ),
+		] );
+
+		$response->header( 'X-WP-Total', $total );
+		$response->header( 'X-WP-TotalPages', (int) ceil( $total / $per_page ) );
+
+		return $response;
+	}
+
+	/**
+	 * GET /wp-agent/v1/history/<id>
+	 *
+	 * Returns a single conversation with its messages.
+	 * Verifies the current user owns the conversation.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function get_conversation( $request ) {
+		global $wpdb;
+
+		$tables          = Database::get_table_names();
+		$conversation_id = (int) $request->get_param( 'id' );
+		$user_id         = get_current_user_id();
+
+		// Fetch conversation and verify ownership.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$conversation = $wpdb->get_row(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT id, user_id, post_id, title, status, model, tokens_used, created_at, updated_at
+				FROM {$tables['conversations']}
+				WHERE id = %d
+				LIMIT 1",
+				$conversation_id
+			),
+			ARRAY_A
+		);
+
+		if ( null === $conversation ) {
+			return new \WP_Error(
+				'not_found',
+				__( 'Conversation not found.', 'wp-agent' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		if ( (int) $conversation['user_id'] !== $user_id ) {
+			return new \WP_Error(
+				'forbidden',
+				__( 'You do not have access to this conversation.', 'wp-agent' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		// Cast numeric fields.
+		$conversation['id']          = (int) $conversation['id'];
+		$conversation['post_id']     = $conversation['post_id'] ? (int) $conversation['post_id'] : null;
+		$conversation['tokens_used'] = (int) $conversation['tokens_used'];
+		unset( $conversation['user_id'] ); // Don't expose user_id in response.
+
+		// Fetch messages.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$messages = $wpdb->get_results(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT id, role, content, metadata, tokens, model, created_at
+				FROM {$tables['messages']}
+				WHERE conversation_id = %d
+				ORDER BY id ASC",
+				$conversation_id
+			),
+			ARRAY_A
+		);
+
+		if ( null === $messages ) {
+			$messages = [];
+		}
+
+		// Parse message metadata and cast fields.
+		foreach ( $messages as &$msg ) {
+			$msg['id']     = (int) $msg['id'];
+			$msg['tokens'] = (int) $msg['tokens'];
+
+			if ( ! empty( $msg['metadata'] ) ) {
+				$decoded = json_decode( $msg['metadata'], true );
+				$msg['metadata'] = is_array( $decoded ) ? $decoded : null;
+			} else {
+				$msg['metadata'] = null;
+			}
+		}
+		unset( $msg );
+
+		return rest_ensure_response( [
+			'conversation' => $conversation,
+			'messages'     => $messages,
+		] );
+	}
+
+	/**
+	 * Define argument schema for GET /history.
+	 *
+	 * @since 1.0.0
+	 * @return array
+	 */
+	private function get_list_args() {
+		return [
+			'page'     => [
+				'type'              => 'integer',
+				'default'           => 1,
+				'sanitize_callback' => 'absint',
+			],
+			'per_page' => [
+				'type'              => 'integer',
+				'default'           => self::DEFAULT_PER_PAGE,
+				'sanitize_callback' => 'absint',
+			],
+		];
+	}
+}

--- a/rest/rest-permissions.php
+++ b/rest/rest-permissions.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * REST Permissions Helper.
+ *
+ * Shared permission check for role-based access control across
+ * chat, stream, history, and action controllers.
+ *
+ * @package WPAgent\REST
+ * @since   1.0.0
+ */
+
+namespace WPAgent\REST;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class REST_Permissions
+ *
+ * @since 1.0.0
+ */
+class REST_Permissions {
+
+	/**
+	 * Check if the current user has an allowed role for WP Agent access.
+	 *
+	 * Checks the user's role against the wp_agent_allowed_roles option.
+	 * Defaults to administrator-only if no option is set.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool True if the user has an allowed role.
+	 */
+	public static function current_user_has_allowed_role() {
+		$user = wp_get_current_user();
+
+		if ( ! $user || ! $user->exists() ) {
+			return false;
+		}
+
+		$allowed_roles = get_option( Settings_Controller::ROLES_OPTION, [ 'administrator' ] );
+
+		if ( ! is_array( $allowed_roles ) || empty( $allowed_roles ) ) {
+			$allowed_roles = [ 'administrator' ];
+		}
+
+		return ! empty( array_intersect( $user->roles, $allowed_roles ) );
+	}
+}

--- a/rest/settings-controller.php
+++ b/rest/settings-controller.php
@@ -1,0 +1,287 @@
+<?php
+/**
+ * Settings REST Controller.
+ *
+ * Handles GET/POST /wp-agent/v1/settings for managing plugin configuration.
+ * Requires manage_options capability (admin-only).
+ *
+ * @package WPAgent\REST
+ * @since   1.0.0
+ */
+
+namespace WPAgent\REST;
+
+use WPAgent\AI\Open_Router_Client;
+use WPAgent\AI\Model_Router;
+use WPAgent\AI\Rate_Limiter;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Settings_Controller
+ *
+ * @since 1.0.0
+ */
+class Settings_Controller {
+
+	/**
+	 * REST namespace.
+	 *
+	 * @var string
+	 */
+	const NAMESPACE = 'wp-agent/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	const ROUTE = '/settings';
+
+	/**
+	 * Option key for default model.
+	 *
+	 * @var string
+	 */
+	const MODEL_OPTION = 'wp_agent_default_model';
+
+	/**
+	 * Option key for allowed roles.
+	 *
+	 * @var string
+	 */
+	const ROLES_OPTION = 'wp_agent_allowed_roles';
+
+	/**
+	 * Register REST routes.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			self::NAMESPACE,
+			self::ROUTE,
+			[
+				[
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_settings' ],
+					'permission_callback' => [ $this, 'check_permissions' ],
+				],
+				[
+					'methods'             => \WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'update_settings' ],
+					'permission_callback' => [ $this, 'check_permissions' ],
+					'args'                => $this->get_update_args(),
+				],
+			]
+		);
+	}
+
+	/**
+	 * Permission check — manage_options required.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return bool|\ WP_Error
+	 */
+	public function check_permissions( $request ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to manage settings.', 'wp-agent' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * GET /wp-agent/v1/settings
+	 *
+	 * Returns current plugin configuration.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return \WP_REST_Response
+	 */
+	public function get_settings( $request ) {
+		$client = Open_Router_Client::get_instance();
+		$router = Model_Router::get_instance();
+
+		return rest_ensure_response( [
+			'has_api_key'   => $client->has_api_key(),
+			'default_model' => $router->get_default_model(),
+			'allowed_roles' => get_option( self::ROLES_OPTION, [ 'administrator' ] ),
+			'rate_limit'    => (int) get_option( 'wp_agent_rate_limit', Rate_Limiter::DEFAULT_MINUTE_LIMIT ),
+			'daily_limit'   => (int) get_option( 'wp_agent_daily_limit', Rate_Limiter::DEFAULT_DAILY_LIMIT ),
+		] );
+	}
+
+	/**
+	 * POST /wp-agent/v1/settings
+	 *
+	 * Saves settings. Only provided fields are updated.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function update_settings( $request ) {
+		$updated = [];
+
+		// API key — validate and encrypt before storing.
+		if ( $request->has_param( 'api_key' ) ) {
+			$api_key = $request->get_param( 'api_key' );
+			$result  = $this->save_api_key( $api_key );
+
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+
+			$updated['api_key'] = true;
+		}
+
+		// Default model — validate against known models.
+		if ( $request->has_param( 'default_model' ) ) {
+			$model  = sanitize_text_field( $request->get_param( 'default_model' ) );
+			$router = Model_Router::get_instance();
+
+			if ( ! $router->is_valid_model( $model ) ) {
+				return new \WP_Error(
+					'invalid_model',
+					__( 'The specified model is not available.', 'wp-agent' ),
+					[ 'status' => 400 ]
+				);
+			}
+
+			update_option( self::MODEL_OPTION, $model );
+			$updated['default_model'] = $model;
+		}
+
+		// Allowed roles — validate against WordPress roles.
+		if ( $request->has_param( 'allowed_roles' ) ) {
+			$roles  = $request->get_param( 'allowed_roles' );
+			$result = $this->save_allowed_roles( $roles );
+
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+
+			$updated['allowed_roles'] = $roles;
+		}
+
+		return rest_ensure_response( [
+			'success' => true,
+			'updated' => $updated,
+		] );
+	}
+
+	/**
+	 * Validate and save an API key.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $api_key The plaintext API key.
+	 * @return true|\WP_Error
+	 */
+	private function save_api_key( $api_key ) {
+		$api_key = trim( $api_key );
+
+		if ( empty( $api_key ) ) {
+			// Allow clearing the key.
+			delete_option( Open_Router_Client::API_KEY_OPTION );
+			return true;
+		}
+
+		// Validate with OpenRouter.
+		$client     = Open_Router_Client::get_instance();
+		$validation = $client->validate_api_key( $api_key );
+
+		if ( is_wp_error( $validation ) ) {
+			return $validation;
+		}
+
+		// Encrypt and store.
+		$encrypted = Open_Router_Client::encrypt_api_key( $api_key );
+
+		if ( false === $encrypted ) {
+			return new \WP_Error(
+				'encryption_failed',
+				__( 'Failed to encrypt the API key. OpenSSL may not be available.', 'wp-agent' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		update_option( Open_Router_Client::API_KEY_OPTION, $encrypted );
+
+		return true;
+	}
+
+	/**
+	 * Validate and save allowed roles.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $roles Array of role slugs.
+	 * @return true|\WP_Error
+	 */
+	private function save_allowed_roles( $roles ) {
+		if ( ! is_array( $roles ) ) {
+			return new \WP_Error(
+				'invalid_roles',
+				__( 'Allowed roles must be an array.', 'wp-agent' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$valid_roles = array_keys( wp_roles()->get_names() );
+		$sanitized   = [];
+
+		foreach ( $roles as $role ) {
+			$role = sanitize_text_field( $role );
+			if ( in_array( $role, $valid_roles, true ) ) {
+				$sanitized[] = $role;
+			}
+		}
+
+		// Always include administrator.
+		if ( ! in_array( 'administrator', $sanitized, true ) ) {
+			array_unshift( $sanitized, 'administrator' );
+		}
+
+		update_option( self::ROLES_OPTION, $sanitized );
+
+		return true;
+	}
+
+	/**
+	 * Define argument schema for POST /settings.
+	 *
+	 * @since 1.0.0
+	 * @return array
+	 */
+	private function get_update_args() {
+		return [
+			'api_key'       => [
+				'type' => 'string',
+				// No sanitize_callback — API keys contain special characters
+				// that sanitize_text_field would corrupt. Handled in save_api_key().
+			],
+			'default_model' => [
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+			'allowed_roles' => [
+				'type'  => 'array',
+				'items' => [
+					'type' => 'string',
+				],
+			],
+		];
+	}
+}

--- a/rest/stream-controller.php
+++ b/rest/stream-controller.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Stream REST Controller.
+ *
+ * SSE (Server-Sent Events) streaming endpoint. Sends AI response chunks
+ * in real time as they arrive from the OpenRouter API.
+ *
+ * @package WPAgent\REST
+ * @since   1.0.0
+ */
+
+namespace WPAgent\REST;
+
+use WPAgent\AI\Orchestrator;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Stream_Controller
+ *
+ * @since 1.0.0
+ */
+class Stream_Controller {
+
+	/**
+	 * REST namespace.
+	 *
+	 * @var string
+	 */
+	const NAMESPACE = 'wp-agent/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	const ROUTE = '/stream';
+
+	/**
+	 * Register REST routes.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			self::NAMESPACE,
+			self::ROUTE,
+			[
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'handle_stream' ],
+				'permission_callback' => [ $this, 'check_permissions' ],
+				'args'                => $this->get_args(),
+			]
+		);
+	}
+
+	/**
+	 * Permission check — edit_posts required.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return bool|\WP_Error
+	 */
+	public function check_permissions( $request ) {
+		if ( ! current_user_can( 'edit_posts' ) || ! REST_Permissions::current_user_has_allowed_role() ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to use the chat.', 'wp-agent' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * POST /wp-agent/v1/stream
+	 *
+	 * Opens an SSE connection and streams AI response chunks.
+	 *
+	 * This method bypasses WP_REST_Server::serve_request() by sending
+	 * headers and data directly, then calling exit. This is the standard
+	 * pattern for SSE in WordPress REST API.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return void|\WP_Error Returns WP_Error only on pre-stream failures.
+	 */
+	public function handle_stream( $request ) {
+		$message         = $request->get_param( 'message' );
+		$conversation_id = $request->get_param( 'conversation_id' );
+		$user_id         = get_current_user_id();
+
+		$options = [];
+
+		if ( $request->has_param( 'post_id' ) ) {
+			$options['post_id'] = (int) $request->get_param( 'post_id' );
+		}
+
+		if ( $request->has_param( 'model' ) ) {
+			$options['model'] = sanitize_text_field( $request->get_param( 'model' ) );
+		}
+
+		// Set SSE headers.
+		header( 'Content-Type: text/event-stream' );
+		header( 'Cache-Control: no-cache' );
+		header( 'X-Accel-Buffering: no' );
+		header( 'Connection: keep-alive' );
+
+		// Flush all existing output buffers.
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- ob_end_flush may warn if no buffer exists.
+		while ( ob_get_level() > 0 ) {
+			@ob_end_flush();
+		}
+
+		// Remove PHP execution timeout for long-running streams.
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- set_time_limit may be disabled.
+		@set_time_limit( 0 );
+
+		// Stream callback — sends SSE data frames to the client.
+		$stream_callback = function ( $chunk ) {
+			echo 'data: ' . wp_json_encode( $chunk ) . "\n\n";
+
+			if ( ob_get_level() > 0 ) {
+				ob_flush();
+			}
+			flush();
+
+			// Reset timeout with each chunk to prevent timeout during active streaming.
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- set_time_limit may be disabled.
+			@set_time_limit( 30 );
+		};
+
+		$result = Orchestrator::get_instance()->handle_stream(
+			$message,
+			$user_id,
+			$conversation_id ? (int) $conversation_id : null,
+			$stream_callback,
+			$options
+		);
+
+		// If the orchestrator returned an error before streaming started,
+		// send it as an SSE error event so the client can handle it.
+		if ( is_wp_error( $result ) ) {
+			echo 'data: ' . wp_json_encode( [
+				'type'    => 'error',
+				'message' => $result->get_error_message(),
+				'code'    => $result->get_error_code(),
+			] ) . "\n\n";
+		}
+
+		// Send stream termination signal.
+		echo "data: [DONE]\n\n";
+
+		if ( ob_get_level() > 0 ) {
+			ob_flush();
+		}
+		flush();
+
+		exit;
+	}
+
+	/**
+	 * Define argument schema for POST /stream.
+	 *
+	 * @since 1.0.0
+	 * @return array
+	 */
+	private function get_args() {
+		return [
+			'message'         => [
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_textarea_field',
+				'validate_callback' => function ( $value ) {
+					if ( empty( trim( $value ) ) ) {
+						return new \WP_Error(
+							'empty_message',
+							__( 'Message cannot be empty.', 'wp-agent' ),
+							[ 'status' => 400 ]
+						);
+					}
+					return true;
+				},
+			],
+			'conversation_id' => [
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+			],
+			'post_id'         => [
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+			],
+			'model'           => [
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+		];
+	}
+}

--- a/src/components/ApiKeyForm.jsx
+++ b/src/components/ApiKeyForm.jsx
@@ -2,13 +2,12 @@ import { useState } from '@wordpress/element';
 import { Container, Title, Input, Button, Text, toast } from '@bsf/force-ui';
 import { KeyRound, CheckCircle } from 'lucide-react';
 
-export default function ApiKeyForm() {
-	const [ apiKey, setApiKey ] = useState( '' );
+const { restUrl, nonce } = window.wpAgentData || {};
+
+export default function ApiKeyForm( { apiKey = '', onApiKeyChange, hasApiKey = false } ) {
 	const [ isValidating, setIsValidating ] = useState( false );
 
-	const hasApiKey = window.wpAgentData?.hasApiKey || false;
-
-	const handleValidate = () => {
+	const handleValidate = async () => {
 		if ( ! apiKey.trim() ) {
 			toast.error( 'Please enter an API key.' );
 			return;
@@ -16,14 +15,36 @@ export default function ApiKeyForm() {
 
 		setIsValidating( true );
 
-		// Placeholder — no REST call yet.
-		setTimeout( () => {
-			setIsValidating( false );
-			toast.success( 'API key validated!', {
-				description:
-					'Your OpenRouter key looks good. Save settings to persist.',
+		try {
+			// Validate by attempting a save — the REST endpoint validates with OpenRouter.
+			const response = await fetch( `${ restUrl }settings`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-WP-Nonce': nonce,
+				},
+				body: JSON.stringify( { api_key: apiKey } ),
 			} );
-		}, 1200 );
+
+			const data = await response.json();
+
+			if ( ! response.ok ) {
+				throw new Error( data.message || 'Validation failed.' );
+			}
+
+			toast.success( 'API key validated and saved!', {
+				description: 'Your OpenRouter key is securely stored.',
+			} );
+
+			// Clear input and update parent state.
+			onApiKeyChange?.( '' );
+		} catch ( error ) {
+			toast.error( 'API key validation failed.', {
+				description: error.message,
+			} );
+		} finally {
+			setIsValidating( false );
+		}
 	};
 
 	return (
@@ -49,7 +70,7 @@ export default function ApiKeyForm() {
 									: 'sk-or-v1-…'
 							}
 							value={ apiKey }
-							onChange={ ( value ) => setApiKey( value ) }
+							onChange={ ( value ) => onApiKeyChange?.( value ) }
 						/>
 					</div>
 					<Button

--- a/src/components/ModelSelector.jsx
+++ b/src/components/ModelSelector.jsx
@@ -1,11 +1,11 @@
-import { useState } from '@wordpress/element';
 import { Container, Title, Select, Text } from '@bsf/force-ui';
 import { Cpu } from 'lucide-react';
 
+// Must match model IDs in ai/model-router.php.
 const MODELS = [
 	{
-		value: 'google/gemini-flash-1.5',
-		label: 'Gemini Flash — Fast',
+		value: 'google/gemini-2.0-flash-001',
+		label: 'Gemini 2.0 Flash — Fast',
 		description: 'Quick responses for simple tasks.',
 	},
 	{
@@ -14,15 +14,13 @@ const MODELS = [
 		description: 'Great balance of speed and quality. Recommended.',
 	},
 	{
-		value: 'anthropic/claude-sonnet',
-		label: 'Claude Sonnet — Powerful',
+		value: 'anthropic/claude-sonnet-4',
+		label: 'Claude Sonnet 4 — Powerful',
 		description: 'Best quality for complex tasks.',
 	},
 ];
 
-export default function ModelSelector() {
-	const [ model, setModel ] = useState( 'openai/gpt-4o-mini' );
-
+export default function ModelSelector( { model = '', onModelChange } ) {
 	const selectedModel = MODELS.find( ( m ) => m.value === model );
 
 	return (
@@ -40,7 +38,7 @@ export default function ModelSelector() {
 				<Select
 					size="md"
 					value={ model }
-					onChange={ ( value ) => setModel( value ) }
+					onChange={ ( value ) => onModelChange?.( value ) }
 				>
 					<Select.Button placeholder="Select a model" />
 					<Select.Options>

--- a/src/components/RolePermissions.jsx
+++ b/src/components/RolePermissions.jsx
@@ -1,26 +1,27 @@
-import { useState } from '@wordpress/element';
 import { Container, Title, Switch, Text } from '@bsf/force-ui';
 import { Shield } from 'lucide-react';
 
-const DEFAULT_ROLES = [
-	{ slug: 'administrator', label: 'Administrator', enabled: true, locked: true },
-	{ slug: 'editor', label: 'Editor', enabled: true, locked: false },
-	{ slug: 'author', label: 'Author', enabled: false, locked: false },
-	{ slug: 'contributor', label: 'Contributor', enabled: false, locked: false },
-	{ slug: 'subscriber', label: 'Subscriber', enabled: false, locked: false },
+const ALL_ROLES = [
+	{ slug: 'administrator', label: 'Administrator', locked: true },
+	{ slug: 'editor', label: 'Editor', locked: false },
+	{ slug: 'author', label: 'Author', locked: false },
+	{ slug: 'contributor', label: 'Contributor', locked: false },
+	{ slug: 'subscriber', label: 'Subscriber', locked: false },
 ];
 
-export default function RolePermissions() {
-	const [ roles, setRoles ] = useState( DEFAULT_ROLES );
-
+export default function RolePermissions( { allowedRoles = [], onRolesChange } ) {
 	const toggleRole = ( slug ) => {
-		setRoles( ( prev ) =>
-			prev.map( ( role ) =>
-				role.slug === slug
-					? { ...role, enabled: ! role.enabled }
-					: role
-			)
-		);
+		if ( ! onRolesChange ) {
+			return;
+		}
+
+		const isEnabled = allowedRoles.includes( slug );
+
+		if ( isEnabled ) {
+			onRolesChange( allowedRoles.filter( ( r ) => r !== slug ) );
+		} else {
+			onRolesChange( [ ...allowedRoles, slug ] );
+		}
 	};
 
 	return (
@@ -36,32 +37,36 @@ export default function RolePermissions() {
 				</Container>
 
 				<Container direction="column" gap="xs">
-					{ roles.map( ( role ) => (
-						<Container
-							key={ role.slug }
-							direction="row"
-							justify="between"
-							align="center"
-							className="rounded-md border border-border-subtle px-4 py-3"
-						>
-							<Container direction="column" gap="xs">
-								<Text size="sm" weight="medium">
-									{ role.label }
-								</Text>
-								{ role.locked && (
-									<Text size="xs" color="secondary">
-										Always enabled
+					{ ALL_ROLES.map( ( role ) => {
+						const isEnabled = allowedRoles.includes( role.slug );
+
+						return (
+							<Container
+								key={ role.slug }
+								direction="row"
+								justify="between"
+								align="center"
+								className="rounded-md border border-border-subtle px-4 py-3"
+							>
+								<Container direction="column" gap="xs">
+									<Text size="sm" weight="medium">
+										{ role.label }
 									</Text>
-								) }
+									{ role.locked && (
+										<Text size="xs" color="secondary">
+											Always enabled
+										</Text>
+									) }
+								</Container>
+								<Switch
+									size="sm"
+									value={ isEnabled }
+									onChange={ () => toggleRole( role.slug ) }
+									disabled={ role.locked }
+								/>
 							</Container>
-							<Switch
-								size="sm"
-								value={ role.enabled }
-								onChange={ () => toggleRole( role.slug ) }
-								disabled={ role.locked }
-							/>
-						</Container>
-					) ) }
+						);
+					} ) }
 				</Container>
 			</Container>
 		</div>

--- a/src/components/StatusCard.jsx
+++ b/src/components/StatusCard.jsx
@@ -1,13 +1,33 @@
 import { Container, Title, Badge, Text } from '@bsf/force-ui';
 import { Activity } from 'lucide-react';
 
-const STATUS_ITEMS = [
-	{ label: 'API Connection', value: 'Not configured', variant: 'yellow' },
-	{ label: 'Current Model', value: 'GPT-4o Mini', variant: 'neutral' },
-	{ label: 'Rate Limit', value: '200 req/min', variant: 'green' },
-];
+const MODEL_LABELS = {
+	'google/gemini-2.0-flash-001': 'Gemini Flash',
+	'openai/gpt-4o-mini': 'GPT-4o Mini',
+	'anthropic/claude-sonnet-4': 'Claude Sonnet 4',
+};
 
-export default function StatusCard() {
+export default function StatusCard( { hasApiKey = false, defaultModel = '', rateLimit = 0 } ) {
+	const modelLabel = MODEL_LABELS[ defaultModel ] || defaultModel || 'Not set';
+
+	const items = [
+		{
+			label: 'API Connection',
+			value: hasApiKey ? 'Connected' : 'Not configured',
+			variant: hasApiKey ? 'green' : 'yellow',
+		},
+		{
+			label: 'Current Model',
+			value: modelLabel,
+			variant: 'neutral',
+		},
+		{
+			label: 'Rate Limit',
+			value: rateLimit ? `${ rateLimit } req/min` : 'Default',
+			variant: 'green',
+		},
+	];
+
 	return (
 		<div className="rounded-lg border border-border-subtle bg-background-primary p-6">
 			<Container direction="column" gap="md">
@@ -17,7 +37,7 @@ export default function StatusCard() {
 				</Container>
 
 				<Container direction="column" gap="sm">
-					{ STATUS_ITEMS.map( ( item ) => (
+					{ items.map( ( item ) => (
 						<Container
 							key={ item.label }
 							direction="row"

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,19 +1,118 @@
+import { useState, useEffect, useCallback } from '@wordpress/element';
 import { Container, Title, Badge, Button, Toaster, toast } from '@bsf/force-ui';
-import { Save } from 'lucide-react';
+import { Save, Loader2 } from 'lucide-react';
 import ApiKeyForm from '../components/ApiKeyForm';
 import ModelSelector from '../components/ModelSelector';
 import RolePermissions from '../components/RolePermissions';
 import StatusCard from '../components/StatusCard';
 import QuickStats from '../components/QuickStats';
 
-const { version } = window.wpAgentData || {};
+const { version, restUrl, nonce } = window.wpAgentData || {};
 
 export default function Settings() {
-	const handleSave = () => {
-		toast.success( 'Settings saved successfully!', {
-			description: 'Your WP Agent configuration has been updated.',
-		} );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ isSaving, setIsSaving ] = useState( false );
+
+	// Settings state — populated from REST API.
+	const [ hasApiKey, setHasApiKey ] = useState( false );
+	const [ apiKey, setApiKey ] = useState( '' );
+	const [ defaultModel, setDefaultModel ] = useState( '' );
+	const [ allowedRoles, setAllowedRoles ] = useState( [ 'administrator' ] );
+	const [ rateLimit, setRateLimit ] = useState( 0 );
+	const [ dailyLimit, setDailyLimit ] = useState( 0 );
+
+	// Fetch settings on mount.
+	const fetchSettings = useCallback( async () => {
+		try {
+			const response = await fetch( `${ restUrl }settings`, {
+				headers: { 'X-WP-Nonce': nonce },
+			} );
+
+			if ( ! response.ok ) {
+				throw new Error( `HTTP ${ response.status }` );
+			}
+
+			const data = await response.json();
+
+			setHasApiKey( data.has_api_key || false );
+			setDefaultModel( data.default_model || '' );
+			setAllowedRoles( data.allowed_roles || [ 'administrator' ] );
+			setRateLimit( data.rate_limit || 0 );
+			setDailyLimit( data.daily_limit || 0 );
+		} catch ( error ) {
+			toast.error( 'Failed to load settings.', {
+				description: error.message,
+			} );
+		} finally {
+			setIsLoading( false );
+		}
+	}, [] );
+
+	useEffect( () => {
+		fetchSettings();
+	}, [ fetchSettings ] );
+
+	// Save all settings.
+	const handleSave = async () => {
+		setIsSaving( true );
+
+		const payload = {};
+
+		// Only send API key if the user typed a new one.
+		if ( apiKey.trim() ) {
+			payload.api_key = apiKey;
+		}
+
+		if ( defaultModel ) {
+			payload.default_model = defaultModel;
+		}
+
+		payload.allowed_roles = allowedRoles;
+
+		try {
+			const response = await fetch( `${ restUrl }settings`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-WP-Nonce': nonce,
+				},
+				body: JSON.stringify( payload ),
+			} );
+
+			const data = await response.json();
+
+			if ( ! response.ok ) {
+				throw new Error( data.message || `HTTP ${ response.status }` );
+			}
+
+			toast.success( 'Settings saved successfully!', {
+				description: 'Your WP Agent configuration has been updated.',
+			} );
+
+			// If API key was saved, clear the input and update status.
+			if ( data.updated?.api_key ) {
+				setApiKey( '' );
+				setHasApiKey( true );
+			}
+		} catch ( error ) {
+			toast.error( 'Failed to save settings.', {
+				description: error.message,
+			} );
+		} finally {
+			setIsSaving( false );
+		}
 	};
+
+	if ( isLoading ) {
+		return (
+			<div className="min-h-screen bg-background-primary p-6 md:p-8 flex items-center justify-center">
+				<Container direction="row" align="center" gap="sm">
+					<Loader2 size={ 20 } className="animate-spin text-icon-secondary" />
+					<span className="text-text-secondary text-sm">Loading settings...</span>
+				</Container>
+			</div>
+		);
+	}
 
 	return (
 		<>
@@ -46,6 +145,8 @@ export default function Settings() {
 						size="md"
 						icon={ <Save size={ 16 } /> }
 						onClick={ handleSave }
+						loading={ isSaving }
+						disabled={ isSaving }
 					>
 						Save Settings
 					</Button>
@@ -55,14 +156,28 @@ export default function Settings() {
 				<div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
 					{ /* Left column — settings */ }
 					<div className="lg:col-span-2 flex flex-col gap-6">
-						<ApiKeyForm />
-						<ModelSelector />
-						<RolePermissions />
+						<ApiKeyForm
+							apiKey={ apiKey }
+							onApiKeyChange={ setApiKey }
+							hasApiKey={ hasApiKey }
+						/>
+						<ModelSelector
+							model={ defaultModel }
+							onModelChange={ setDefaultModel }
+						/>
+						<RolePermissions
+							allowedRoles={ allowedRoles }
+							onRolesChange={ setAllowedRoles }
+						/>
 					</div>
 
 					{ /* Right column — status */ }
 					<div className="flex flex-col gap-6">
-						<StatusCard />
+						<StatusCard
+							hasApiKey={ hasApiKey }
+							defaultModel={ defaultModel }
+							rateLimit={ rateLimit }
+						/>
 						<QuickStats />
 					</div>
 				</div>


### PR DESCRIPTION
## **User description**
## Summary

Closes #17

- Create 7 REST API routes across 5 controllers (settings, chat, stream, history, action)
- Add shared `REST_Permissions` helper enforcing `wp_agent_allowed_roles` on all non-settings endpoints
- Wire up React settings page to fetch/save via REST API — settings now persist across refreshes
- Fix stale model IDs in ModelSelector and wrong option key in assets-manager.php

## Test plan

- [ ] Visit Settings page — should load current settings from API (not hardcoded defaults)
- [ ] Toggle role permissions, change model, hit Save — refresh and verify they persist
- [ ] Validate API key button calls real OpenRouter endpoint
- [ ] Unauthenticated `curl http://localhost:10068/wp-json/wp-agent/v1/settings` returns 403
- [ ] All 7 routes visible at `/wp-json/wp-agent/v1`
- [ ] StatusCard reflects live API connection status and selected model


___

## **CodeAnt-AI Description**
Add REST API for chat, streaming, history, actions and persist settings in the admin UI

### What Changed
- Exposes REST endpoints under /wp-agent/v1 for settings (GET/POST), chat (sync POST), stream (SSE POST), history (list and detail GET), and action execute/undo (POST); endpoints enforce role-based permissions and appropriate capability checks
- Settings page now fetches current configuration from the API, shows live status, and saves changes (API key, default model, allowed roles, rate limits) back to the server so settings persist across page refreshes
- Admin UI components updated to use server-backed values: model selector IDs aligned with backend router, role permissions toggle reads/saves allowed roles, API key validation calls the REST API, status card shows connection/model/rate data, and save button shows loading state
- Small fix: the frontend checks the correct stored API key option for accurate "has API key" status

### Impact
`✅ Settings persist across refreshes`
`✅ Clearer access control for chat and history (role-based restrictions)`
`✅ Real-time streaming responses available via SSE`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
